### PR TITLE
Implemented OCC fix for orders and tickets microservice due to the wa…

### DIFF
--- a/orders/src/events/listeners/ticket-updated-listener.ts
+++ b/orders/src/events/listeners/ticket-updated-listener.ts
@@ -15,7 +15,7 @@ export class TicketUpdatedListener extends Listener<TicketUpdatedEvent> {
   }
   
   async onMessage(data: TicketUpdatedEvent['data'], msg: Message): Promise<void> {
-    const { id, title, price, __v } = data;
+    const { title, price, __v} = data;
     const ticket = await Ticket.findByIdAndOldVersion(data)
     
     if (!ticket) {
@@ -23,12 +23,10 @@ export class TicketUpdatedListener extends Listener<TicketUpdatedEvent> {
     }
     
     // Update ticket & save
-    ticket.set({ title, price });
+    ticket.set({ title, price, __v });
     await ticket.save();
 
     msg.ack();
   }
   
 }
-
-// new TicketCreatedListener(natsWrapper)

--- a/orders/src/model/ticket.ts
+++ b/orders/src/model/ticket.ts
@@ -36,7 +36,6 @@ const ticketSchema = new Schema<TicketAttrs, TicketModel, TicketMethods>({
   },
 }, {
   timestamps: true,
-  optimisticConcurrency: true,
   toJSON: {
     transform(doc, ret) {
       ret.id = ret._id;
@@ -69,6 +68,16 @@ ticketSchema.methods.isReserved = async function(): Promise<boolean> {
 
   return !!reservedOrder;
 };
+
+ticketSchema.pre('save', function(done) {
+  if (!this.isNew) {
+    this.$where = {
+      __v: this.get('__v') - 1,
+    }
+  }
+
+  done();
+});
 
 
 const Ticket: TicketModel = mongoose.model<TicketAttrs, TicketModel>('ticket', ticketSchema);

--- a/orders/src/routes/delete.ts
+++ b/orders/src/routes/delete.ts
@@ -21,19 +21,21 @@ router.delete(
     } 
 
     order.status = OrderStatus.CANCELLED;
-
+    const isUpdated = order.isModified();
     await order.save();
 
-    new OrderCancelledPublisher(natsWrapper.client).publish({
-      id: order.id,
-      __v: order.__v,
-      status: order.status,
-      userId: order.userId.toString(),
-      ticket: {
-        id: order.ticket.id,
-        price: order.ticket.price,
-      },
-    });
+    if (isUpdated) {
+      new OrderCancelledPublisher(natsWrapper.client).publish({
+        id: order.id,
+        __v: order.__v,
+        status: order.status,
+        userId: order.userId.toString(),
+        ticket: {
+          id: order.ticket.id,
+          price: order.ticket.price,
+        },
+      });
+    }
 
     res.status(204).send({
       message: 'Order cancelled successfully',

--- a/tickets/src/routes/update.ts
+++ b/tickets/src/routes/update.ts
@@ -48,10 +48,13 @@ router.put(
       price
     })
 
+    const isUpdated = ticket.isModified();
+
     // Saving the changes to database
     await ticket.save();
 
     // publish the event
+    if (isUpdated) {
       new TickerUpdatedPublisher(natsWrapper.client).publish({
         id: ticket.id,
         title: ticket.title,
@@ -59,6 +62,7 @@ router.put(
         userId: ticket.userId.toString(),
         __v: ticket.__v
       });
+    }
 
     res
       .status(200)


### PR DESCRIPTION
# OCC(Optimistic Concurrency Control) Fix
Implemented OCC fix for orders and tickets microservice due to the way save() works in mongoose as document version is not updated when there are no changes.

## Issue
When order is created or cancelled the OrderCreatedEvent or the OrderUpdatedEvent emitted does updates the ticket document and its version in the tickets microservice but TicketUpdated event emitted due to above Ticket document update fails to update the ticket doc version in the orders microservice as it only contains title and price which are unchanged when Order is created or cancelled.

This leaves Ticket document in the Ticket microservice and the same document in the Order Microservice having different versions.

## Fix

**Approach we used is that events are emitted from the root microservice of the document only when actual update or version change has taken place, and when receiving an event we need to ensure to forcefully update the local data of microservice even when the new document is same as old one(needed because we need to ensure version of the same document are same across all microservices)**

- Removing OCC from the tickets model of the orders microservice
- Added pre save hook to add where query to perform previous version check in ticket model in orders microservice.
- Emitting TicketUpdatedEvent from the update route of the ticket microservice only when the ticket is actually updated.
- Doing the same check when order is cancelled.

 